### PR TITLE
Fixed Logger flag and added auto-upstream feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,6 @@ git_ai_commit config --openai-key=<insert-your-key>
   ```bash
   git_ai_commit help
   ```
-
-🤖 **generate**, **-g**:
-  This subcommand generates a desired number of commit messages
-
-  ```bash
-  git_ai_commit generate <int> 
-  ```
-
 ## Contributing
 
 If you would like to contribute code and improve our product, please read our

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ git_ai_commit config --openai-key=<insert-your-key>
   git_ai_commit config --openai-key=<your-new-key> 
   ```
 
-- ❌ **--reset**, **-r**:
-  Use this flag to remove the current OpenAI API key from the configuration.
+- 🔄 **--reset**, **-r**:
+  Use this flag to reset the entire configuration database to its default state.
 
   ```bash
   git_ai_commit config --reset
   ```
+
+  This will reset all settings, including the OpenAI API key and logger status
 
 - 🖨️ **--logger**, **-l**:
   This flag displays the log status for the CLI

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -1,23 +1,23 @@
+from ai_commit_msg.services.config_service import ConfigService
+from ai_commit_msg.services.local_db_service import LocalDbService
 from ai_commit_msg.services.openai_service import OpenAiService
 from ai_commit_msg.utils.logger import Logger
 
 def config_handler(args):
-    if args.openai_key is None:
-        Logger().log("No OpenAI API key provided")
-        return None
-
-    if args.openai_key.strip() == "":
-        OpenAiService.reset_openai_api_key()
-        Logger().log("OpenAI API key has been reset")
-        return None
-    elif args.openai_key:
+    config_service = ConfigService()
+    if args.openai_key:
         OpenAiService.set_openai_api_key(args.openai_key)
-        Logger().log("OpenAI API key set successfully")
+        Logger().log("OpenAI API key has been reset")
         return None
 
     if args.reset:
-        OpenAiService.reset_openai_api_key()
+        LocalDbService().reset_db();
         Logger().log("OpenAI API key has been reset")
+        return None
+
+    if args.logger is not None:
+        config_service.set_logger_enabled(args.logger)
+        print(f"Logger {'enabled' if args.logger else 'disabled'}")
         return None
 
     help_message = (

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -18,7 +18,7 @@ def config_handler(args):
 
     if args.logger:
         config_service.set_logger_enabled(args.logger)
-        print(f"Logger {'enabled' if args.logger else 'disabled'}")
+        Logger().log(f"Logger {'enabled' if args.logger else 'disabled'}")
         return None
 
     help_message = (

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -17,7 +17,7 @@ def config_handler(args):
         Logger().log("OpenAI API key has been reset")
         return None
 
-    if args.logger:
+    if args.logger is not None:
         config_service.set_logger_enabled(args.logger)
         Logger().log(f"Logger {'enabled' if args.logger else 'disabled'}")
         return None

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -18,8 +18,8 @@ def config_handler(args):
         return None
 
     if args.logger is not None:
-        config_service.logger_enabled(args.logger)
-        Logger().log(f"Logger {'enabled' if args.logger else 'disabled'}")
+        config_service.set_logger_enabled(args.logger)
+        Logger().log("Logger " + ("enabled" if args.logger else "disabled"))
         return None
 
     help_message = (

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -5,9 +5,10 @@ from ai_commit_msg.utils.logger import Logger
 
 def config_handler(args):
     config_service = ConfigService()
+
     if args.openai_key:
         OpenAiService.set_openai_api_key(args.openai_key)
-        Logger().log("OpenAI API key has been reset")
+        Logger().log("OpenAI API key set successfully")
         return None
 
     if args.reset:

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -12,6 +12,7 @@ def config_handler(args):
         return None
 
     if args.reset:
+        # reset the db the entire db
         LocalDbService().reset_db();
         Logger().log("OpenAI API key has been reset")
         return None

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -16,7 +16,7 @@ def config_handler(args):
         Logger().log("OpenAI API key has been reset")
         return None
 
-    if args.logger is not None:
+    if args.logger:
         config_service.set_logger_enabled(args.logger)
         print(f"Logger {'enabled' if args.logger else 'disabled'}")
         return None

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -18,7 +18,7 @@ def config_handler(args):
         return None
 
     if args.logger is not None:
-        config_service.set_logger_enabled(args.logger)
+        config_service.logger_enabled(args.logger)
         Logger().log(f"Logger {'enabled' if args.logger else 'disabled'}")
         return None
 

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -30,8 +30,9 @@ Would you like to commit your changes? (y/n): """
 
     if has_upstream:
         execute_cli_command(['git', 'push'], output=True)
-    else:
-        set_upstream = input(f"No upstream branch found for '{current_branch}'. Set upstream? (y/n): ")
+        return
+    if not has_upstream:
+        set_upstream = input(f"No upstream branch found for '{current_branch}'. This will run: 'git push --set-upstream origin {current_branch}'. Set upstream? (y/n): ")
         if set_upstream.lower() == 'y':
             execute_cli_command(['git', 'push', '--set-upstream', 'origin', current_branch], output=True)
             print(f"🔄 Upstream branch set for '{current_branch}'")

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -31,12 +31,12 @@ Would you like to commit your changes? (y/n): """
     if has_upstream:
         execute_cli_command(['git', 'push'], output=True)
         return
-    if not has_upstream:
-        set_upstream = input(f"No upstream branch found for '{current_branch}'. This will run: 'git push --set-upstream origin {current_branch}'. Set upstream? (y/n): ")
-        if set_upstream.lower() == 'y':
-            execute_cli_command(['git', 'push', '--set-upstream', 'origin', current_branch], output=True)
-            print(f"🔄 Upstream branch set for '{current_branch}'")
-        else:
-            print("Skipping push. You can set upstream manually")
+
+    set_upstream = input(f"No upstream branch found for '{current_branch}'. This will run: 'git push --set-upstream origin {current_branch}'. Set upstream? (y/n): ")
+    if set_upstream.lower() == 'y':
+        execute_cli_command(['git', 'push', '--set-upstream', 'origin', current_branch], output=True)
+        print(f"🔄 Upstream branch set for '{current_branch}'")
+    else:
+        print("Skipping push. You can set upstream manually")
 
     return 0

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -29,7 +29,7 @@ Would you like to commit your changes? (y/n): """
     execute_cli_command(['git', 'commit', '-m', ai_gen_commit_msg], output=True)
 
     current_branch = GitService.get_current_branch()
-    has_upstream = GitService.has_upstream(current_branch)
+    has_upstream = GitService.has_upstream_branch(current_branch)
 
     if has_upstream:
       execute_cli_command(['git', 'push'], output=True)

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -3,7 +3,6 @@ from ai_commit_msg.services.git_service import GitService
 from ai_commit_msg.utils.utils import execute_cli_command
 
 def gen_ai_commit_message_handler():
-
     if(len(GitService.get_staged_files()) == 0):
       print("🚨 No files are staged for commit. Run `git add` to stage some of your changes")
       return
@@ -25,9 +24,7 @@ Would you like to commit your changes? (y/n): """
       print("🚨 Invalid input. Exiting.")
       return
 
-
     execute_cli_command(['git', 'commit', '-m', ai_gen_commit_msg], output=True)
-
     current_branch = GitService.get_current_branch()
     has_upstream = GitService.has_upstream_branch(current_branch)
 

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -29,10 +29,13 @@ Would you like to commit your changes? (y/n): """
     has_upstream = GitService.has_upstream_branch(current_branch)
 
     if has_upstream:
-      execute_cli_command(['git', 'push'], output=True)
+        execute_cli_command(['git', 'push'], output=True)
     else:
-      print(f"No upstream branch found. Setting upstream for branch '{current_branch}'")
-      execute_cli_command(['git', 'push', '--set-upstream', 'origin', current_branch], output=True)
-      print(f"🔄 Upstream branch set for '{current_branch}'")
+        set_upstream = input(f"No upstream branch found for '{current_branch}'. Set upstream? (y/n): ")
+        if set_upstream.lower() == 'y':
+            execute_cli_command(['git', 'push', '--set-upstream', 'origin', current_branch], output=True)
+            print(f"🔄 Upstream branch set for '{current_branch}'")
+        else:
+            print("Skipping push. You can set upstream manually")
 
     return 0

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -36,5 +36,6 @@ Would you like to commit your changes? (y/n): """
     else:
       print(f"No upstream branch found. Setting upstream for branch '{current_branch}'")
       execute_cli_command(['git', 'push', '--set-upstream', 'origin', current_branch], output=True)
+      print(f"🔄 Upstream branch set for '{current_branch}'")
 
     return 0

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -1,9 +1,9 @@
-
 from ai_commit_msg.core.gen_commit_msg import generate_commit_message
 from ai_commit_msg.services.git_service import GitService
 from ai_commit_msg.utils.utils import execute_cli_command
 
 def gen_ai_commit_message_handler():
+
     if(len(GitService.get_staged_files()) == 0):
       print("🚨 No files are staged for commit. Run `git add` to stage some of your changes")
       return

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -25,7 +25,16 @@ Would you like to commit your changes? (y/n): """
       print("🚨 Invalid input. Exiting.")
       return
 
+
     execute_cli_command(['git', 'commit', '-m', ai_gen_commit_msg], output=True)
-    execute_cli_command(['git', 'push'], output=True)
+
+    current_branch = GitService.get_current_branch()
+    has_upstream = GitService.has_upstream(current_branch)
+
+    if has_upstream:
+      execute_cli_command(['git', 'push'], output=True)
+    else:
+      print(f"No upstream branch found. Setting upstream for branch '{current_branch}'")
+      execute_cli_command(['git', 'push', '--set-upstream', 'origin', current_branch], output=True)
 
     return 0

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -24,12 +24,9 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
 
     # Config command
     config_parser = subparsers.add_parser('config', help='🛠️ Configure the tool settings')
-    config_parser.add_argument('-k', '--openai-key', dest='openai_key',
-                               help='🔑 Set your OpenAI API key for AI-powered commit messages')
-    config_parser.add_argument('-r', '--reset', action='store_true',
-                               help='🔄 Reset the OpenAI API key to default')
-    config_parser.add_argument('-l', '--logger', type=lambda x: (str(x).lower() == 'true'),
-                               help='📝 Enable or disable logging (true/false) for debugging')
+    config_parser.add_argument('-k', '--openai-key', dest='openai_key',help='🔑 Set your OpenAI API key for AI-powered commit messages')
+    config_parser.add_argument('-r', '--reset', action='store_true',help='🔄 Reset the OpenAI API key to default')
+    config_parser.add_argument('-l', '--logger', type=lambda x: (str(x).lower() == 'true'),help='📝 Enable or disable logging (true/false) for debugging')
 
     # Help command
     subparsers.add_parser('help', help='Display this help message')

--- a/ai_commit_msg/services/config_service.py
+++ b/ai_commit_msg/services/config_service.py
@@ -14,7 +14,6 @@ class ConfigService:
         raw_json_db = LocalDbService().get_db()[CONFIG_COLLECTION_KEY]
         return raw_json_db
 
-    @staticmethod
     def set_logger_enabled(enabled):
         config = ConfigService.get_config()
         config["logger_enabled"] = enabled

--- a/ai_commit_msg/services/config_service.py
+++ b/ai_commit_msg/services/config_service.py
@@ -14,7 +14,7 @@ class ConfigService:
         raw_json_db = LocalDbService().get_db()[CONFIG_COLLECTION_KEY]
         return raw_json_db
 
-    def set_logger_enabled(self, enabled):
+    def logger_enabled(self, enabled):
         config = ConfigService.get_config()
         config["logger_enabled"] = enabled
         LocalDbService().set_db({CONFIG_COLLECTION_KEY: config})

--- a/ai_commit_msg/services/config_service.py
+++ b/ai_commit_msg/services/config_service.py
@@ -14,7 +14,8 @@ class ConfigService:
         raw_json_db = LocalDbService().get_db()[CONFIG_COLLECTION_KEY]
         return raw_json_db
 
-    def logger_enabled(self, enabled):
+    def set_logger_enabled(self, enabled):
         config = ConfigService.get_config()
         config["logger_enabled"] = enabled
         LocalDbService().set_db({CONFIG_COLLECTION_KEY: config})
+        self.logger_enabled = enabled

--- a/ai_commit_msg/services/config_service.py
+++ b/ai_commit_msg/services/config_service.py
@@ -14,7 +14,7 @@ class ConfigService:
         raw_json_db = LocalDbService().get_db()[CONFIG_COLLECTION_KEY]
         return raw_json_db
 
-    def set_logger_enabled(enabled):
+    def set_logger_enabled(self, enabled):
         config = ConfigService.get_config()
         config["logger_enabled"] = enabled
         LocalDbService().set_db({CONFIG_COLLECTION_KEY: config})

--- a/ai_commit_msg/services/git_service.py
+++ b/ai_commit_msg/services/git_service.py
@@ -46,3 +46,12 @@ class GitService:
   def get_staged_files():
     staged_files = execute_cli_command(['git', 'diff', '--name-only', '--cached']).stdout.splitlines()
     return staged_files
+
+  @staticmethod
+  def get_current_branch():
+    return execute_cli_command(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).stdout.strip()
+
+  @staticmethod
+  def has_upstream_branch(branch_name):
+    result = execute_cli_command(['git', 'rev-parse', '--abbrev-ref', f'{branch_name}@{{u}}'], check=False)
+    return result.returncode == 0

--- a/ai_commit_msg/services/git_service.py
+++ b/ai_commit_msg/services/git_service.py
@@ -53,5 +53,8 @@ class GitService:
 
   @staticmethod
   def has_upstream_branch(branch_name):
-    result = execute_cli_command(['git', 'rev-parse', '--abbrev-ref', f'{branch_name}@{{u}}'], check=False)
-    return result.returncode == 0
+    try:
+        execute_cli_command(['git', 'rev-parse', '--abbrev-ref', f'{branch_name}@{{u}}'])
+        return True
+    except Exception:
+        return False

--- a/ai_commit_msg/services/local_db_service.py
+++ b/ai_commit_msg/services/local_db_service.py
@@ -40,3 +40,6 @@ class LocalDbService:
     def append_db(self, data):
         with open(self.db_path, 'a') as db:
             db.write(data)
+
+    def reset_db(self):
+        self.set_db(default_db)

--- a/ai_commit_msg/services/openai_service.py
+++ b/ai_commit_msg/services/openai_service.py
@@ -32,9 +32,3 @@ class OpenAiService:
         raw_json_db = LocalDbService().get_db()
         raw_json_db[CONFIG_COLLECTION_KEY]["openai_api_key"] = api_key
         LocalDbService().set_db(raw_json_db)
-
-    @staticmethod
-    def reset_openai_api_key():
-        raw_json_db = LocalDbService().get_db()
-        raw_json_db[CONFIG_COLLECTION_KEY]["openai_api_key"] = ""
-        LocalDbService().set_db(raw_json_db)

--- a/ai_commit_msg/services/openai_service.py
+++ b/ai_commit_msg/services/openai_service.py
@@ -3,15 +3,16 @@ from openai import OpenAI
 from ai_commit_msg.services.local_db_service import LocalDbService, CONFIG_COLLECTION_KEY
 
 class OpenAiService:
+    client = None
     def __init__(self):
       api_key = OpenAiService.get_openai_api_key()
 
       if(api_key is None or api_key == ""):
-        Logger().log("""OpenAI API key is not set. Run the following command to set the key:
+        raise Exception("""
+        OpenAI API key is not set. Run the following command to set the key:
 
-gen_ai_commit_message_cli config --openai-key=<insert-your-key>
-                        """)
-        return None
+        git_ai_commit config --openai-key=<insert-your-key>
+        """)
       self.client = OpenAI(api_key=api_key)
 
     def chat_with_openai(self, messages):

--- a/ai_commit_msg/utils/logger.py
+++ b/ai_commit_msg/utils/logger.py
@@ -36,4 +36,4 @@ class Logger:
     return logged_string
 
   def is_enabled(self):
-    return ConfigService.logger_enabled
+    return ConfigService().logger_enabled


### PR DESCRIPTION
## Description

In this PR I added a feature and fixed a bug

Bugs
- polished the `logger` flag functionality in `./cli/config_handler.py` that was caused by rebasing in previous PR's

New Features:
- added a feature to `./cli/gen_ai_commit_message_handler.py` to handle the case if the user tries to auto commit on a branch that hasn't been upstreamed with main yet!

## Test Plan

### `--logger`, `-l`

long version
```
git_ai_commit config --logger true
```
short version
```
git_ai_commit config -l true
```

expected output:
```
Logger enabled
```

Testing for false

long version
```
git_ai_commit config --logger false
```
short version
```
git_ai_commit config -l false
```

expected output:
```
Logger disabled
```


### Handle the case where user's current branch has not upstreamed yet

```
git checkout -b <your-branch-name>
```

```
pip3 install . && pre-commit install && pre-commit autoupdate
```

```
git add .
```

```
git_ai_commit_message
```

expected_output:
```
No upstream branch found. Setting upstream for branch <your-branch-anme >
git push ---set-upstream origin <your-branch-anme >
```