### PR TITLE
Avoid overriding any existing commit message from the user

### DIFF
--- a/ai_commit_msg/prepare_commit_msg_hook.py
+++ b/ai_commit_msg/prepare_commit_msg_hook.py
@@ -10,7 +10,7 @@ def prepare_commit_msg_hook():
 
   Logger().log("Filtered content: " + filtered_content)
 
-  if(existing_content != ""):
+  if(filtered_content != ""):
     Logger().log("Commit message already exists, skipping AI commit message generation")
     return
 

--- a/ai_commit_msg/prepare_commit_msg_hook.py
+++ b/ai_commit_msg/prepare_commit_msg_hook.py
@@ -4,19 +4,15 @@ from ai_commit_msg.utils.logger import Logger
 
 def prepare_commit_msg_hook():
   existing_content = GitService.read_commit_editmsg_file()
-  Logger().log("Existing content: " + existing_content)
 
+  # filter out any lines that start with a "#"
   filtered_content = "\n".join([line for line in existing_content.splitlines() if not line.strip().startswith('#')])
-
-  Logger().log("Filtered content: " + filtered_content.strip())
 
   if(filtered_content != ""):
     Logger().log("Commit message already exists, skipping AI commit message generation")
     return
 
   commit_message = "✨" + generate_commit_message()
-
-  Logger().log("Generated commit message: " + commit_message)
 
   GitService.update_commit_message(commit_message)
 

--- a/ai_commit_msg/prepare_commit_msg_hook.py
+++ b/ai_commit_msg/prepare_commit_msg_hook.py
@@ -3,6 +3,10 @@ from ai_commit_msg.services.git_service import GitService
 from ai_commit_msg.utils.logger import Logger
 
 def prepare_commit_msg_hook():
+  existing_content = GitService.read_commit_editmsg_file()
+
+  Logger().log("Existing content: " + existing_content)
+
   commit_message = "✨" + generate_commit_message()
 
   Logger().log("Generated commit message: " + commit_message)

--- a/ai_commit_msg/prepare_commit_msg_hook.py
+++ b/ai_commit_msg/prepare_commit_msg_hook.py
@@ -8,7 +8,7 @@ def prepare_commit_msg_hook():
 
   filtered_content = "\n".join([line for line in existing_content.splitlines() if not line.strip().startswith('#')])
 
-  Logger().log("Filtered content: " + filtered_content)
+  Logger().log("Filtered content: " + filtered_content.strip())
 
   if(filtered_content != ""):
     Logger().log("Commit message already exists, skipping AI commit message generation")

--- a/ai_commit_msg/prepare_commit_msg_hook.py
+++ b/ai_commit_msg/prepare_commit_msg_hook.py
@@ -4,8 +4,11 @@ from ai_commit_msg.utils.logger import Logger
 
 def prepare_commit_msg_hook():
   existing_content = GitService.read_commit_editmsg_file()
-
   Logger().log("Existing content: " + existing_content)
+
+  filtered_content = "\n".join([line for line in existing_content.splitlines() if not line.strip().startswith('#')])
+
+  Logger().log("Filtered content: " + filtered_content)
 
   if(existing_content != ""):
     Logger().log("Commit message already exists, skipping AI commit message generation")

--- a/ai_commit_msg/prepare_commit_msg_hook.py
+++ b/ai_commit_msg/prepare_commit_msg_hook.py
@@ -7,6 +7,10 @@ def prepare_commit_msg_hook():
 
   Logger().log("Existing content: " + existing_content)
 
+  if(existing_content != ""):
+    Logger().log("Commit message already exists, skipping AI commit message generation")
+    return
+
   commit_message = "✨" + generate_commit_message()
 
   Logger().log("Generated commit message: " + commit_message)

--- a/ai_commit_msg/services/git_service.py
+++ b/ai_commit_msg/services/git_service.py
@@ -21,10 +21,8 @@ class GitService:
     return script_directory
 
   @staticmethod
-  def update_commit_message(commit_message):
+  def read_commit_editmsg_file():
     git_directory = GitService.get_repo_root_directory()
-
-    # open COMMIT_EDITMSG file to add the generated commit message
     commit_editmsg_file = git_directory + '/.git/COMMIT_EDITMSG'
 
     existing_content = ""
@@ -34,6 +32,17 @@ class GitService:
         existing_content = file.read()
     except FileNotFoundError:
       pass
+
+    return existing_content
+
+  @staticmethod
+  def update_commit_message(commit_message):
+    git_directory = GitService.get_repo_root_directory()
+
+    # open COMMIT_EDITMSG file to add the generated commit message
+    commit_editmsg_file = git_directory + '/.git/COMMIT_EDITMSG'
+
+    existing_content = GitService.read_commit_editmsg_file()
 
     new_content = commit_message + '\n' + existing_content
 

--- a/ai_commit_msg/services/git_service.py
+++ b/ai_commit_msg/services/git_service.py
@@ -21,14 +21,17 @@ class GitService:
     return script_directory
 
   @staticmethod
-  def read_commit_editmsg_file():
+  def get_commit_editmsg_file_path():
     git_directory = GitService.get_repo_root_directory()
     commit_editmsg_file = git_directory + '/.git/COMMIT_EDITMSG'
+    return commit_editmsg_file
 
+  @staticmethod
+  def read_commit_editmsg_file():
     existing_content = ""
 
     try:
-      with open(commit_editmsg_file, 'r') as file:
+      with open(GitService.get_commit_editmsg_file_path(), 'r') as file:
         existing_content = file.read()
     except FileNotFoundError:
       pass
@@ -37,16 +40,12 @@ class GitService:
 
   @staticmethod
   def update_commit_message(commit_message):
-    git_directory = GitService.get_repo_root_directory()
-
     # open COMMIT_EDITMSG file to add the generated commit message
-    commit_editmsg_file = git_directory + '/.git/COMMIT_EDITMSG'
-
     existing_content = GitService.read_commit_editmsg_file()
 
     new_content = commit_message + '\n' + existing_content
 
-    with open(commit_editmsg_file, 'w') as file:
+    with open(GitService.get_commit_editmsg_file_path(), 'w') as file:
       file.write(new_content)
 
     return 0


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR patches an issue where the git hook overrides existing commit messages with the AI generated one.

The proposed patch involves checking the `./.git/COMMIT_EDITMSG` before we continue to the generation logic. If the file is empty we infer that there is no existing commit message and the other way around 

## Test Plan

<!-- Provide details of a testing plan that includes details on how to reproduce and success parameters. Provide screenshots/videos of log, output, etc. -->

Build and install to obtain the latest changes

```bash
pip install . && pre-commit install && pre-commit autoupdate
```

Attempt a commit with an empty message, and expect our AI-generated commit to show up in the editor

```
git commit
``` 


Attempt a commit with a message, and expect to continue the commit with that manually typed message

```bash
git commit -m "manually typed commit msg"
```