### PR TITLE
✨Added local database display functionality

### DIFF
--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -22,12 +22,7 @@ def config_handler(args):
         Logger().log("Logger " + ("enabled" if args.logger else "disabled"))
         return None
 
-    help_message = (
-        "No valid configuration option provided. You can use:\n"
-        "     -k, --openai-key Set OpenAI API key (or reset if empty)\n"
-        "     -r, --reset Reset the OpenAI API key\n"
-        "     -l, --logger Enable or disable logging (true/false)\n"
-        "     -h, --help Display this help message"
-    )
-    Logger().log(help_message)
+    display_config_db = LocalDbService().display_db()
+    Logger().log(display_config_db)
+
     return None

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -7,6 +7,7 @@ from typing import Sequence
 from ai_commit_msg.cli.config_handler import config_handler
 from ai_commit_msg.cli.gen_ai_commit_message_handler import gen_ai_commit_message_handler
 from ai_commit_msg.prepare_commit_msg_hook import prepare_commit_msg_hook
+from ai_commit_msg.services.local_db_service import LocalDbService
 from ai_commit_msg.utils.logger import Logger
 
 def called_from_git_hook():
@@ -15,6 +16,11 @@ def called_from_git_hook():
 def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     if called_from_git_hook():
         return prepare_commit_msg_hook()
+
+    if len(argv) == 1 and argv[0] == 'config':
+        local_db_service = LocalDbService()
+        local_db_service.display_db()
+        return 0
 
     if len(argv) == 0:
         return gen_ai_commit_message_handler()
@@ -34,6 +40,8 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     args = parser.parse_args(argv)
 
     if args.command == 'config':
+        if len(argv) == 1:
+            return gen_ai_commit_message_handler()
         config_handler(args)
     elif args.command == 'help':
         parser.print_help()

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -17,11 +17,6 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     if called_from_git_hook():
         return prepare_commit_msg_hook()
 
-    if len(argv) == 1 and argv[0] == 'config':
-        local_db_service = LocalDbService()
-        local_db_service.display_db()
-        return 0
-
     if len(argv) == 0:
         return gen_ai_commit_message_handler()
 
@@ -40,8 +35,6 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     args = parser.parse_args(argv)
 
     if args.command == 'config':
-        if len(argv) == 1:
-            return gen_ai_commit_message_handler()
         config_handler(args)
     elif args.command == 'help':
         parser.print_help()

--- a/ai_commit_msg/services/local_db_service.py
+++ b/ai_commit_msg/services/local_db_service.py
@@ -46,3 +46,6 @@ class LocalDbService:
 
     def reset_db(self):
         self.set_db(default_db)
+
+    def display_db(self):
+        print(self.get_db())

--- a/ai_commit_msg/services/local_db_service.py
+++ b/ai_commit_msg/services/local_db_service.py
@@ -48,4 +48,6 @@ class LocalDbService:
         self.set_db(default_db)
 
     def display_db(self):
-        print(self.get_db())
+        db_contents = self.get_db()
+        formatted_db = json.dumps(db_contents, indent=2)
+        return f"Current Database Contents:\n{formatted_db}"


### PR DESCRIPTION
## Description

In this PR we adjusted `git_ai_commit config` to display local database configuration

## Test Plan

```
 pip3 install . && pre-commit install && pre-commit autoupdate
```

### Attempt to display to display local database configuration
```
git_ai_commit config
```

Excepted output

```
Current Database Contents:
{
  "config": {
    "model": "Model-Type",
    "anthropic_api_key": "",
    "logger_enabled": true,
    "openai_api_key": ""
  }
}
```