### PR TITLE
enable support for setting multiple config at once

### DIFF
--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -6,28 +6,32 @@ from ai_commit_msg.utils.logger import Logger
 def config_handler(args):
     config_service = ConfigService()
 
+    has_updated = False
+
     if args.openai_key:
         OpenAiService.set_openai_api_key(args.openai_key)
         Logger().log("OpenAI API key set successfully")
-        return None
+        has_updated = True
 
     if args.reset:
         # reset the db the entire db
         LocalDbService().reset_db();
         Logger().log("OpenAI API key has been reset")
-        return None
+        has_updated = True
 
     if args.logger is not None:
         config_service.set_logger_enabled(args.logger)
         Logger().log("Logger " + ("enabled" if args.logger else "disabled"))
-        return None
+        has_updated = True
 
     if args.model:
         config_service.set_model(args.model)
         Logger().log("Model set to " + args.model)
-        return None
+        has_updated = True
 
-    display_config_db = LocalDbService().display_db()
-    Logger().log(display_config_db)
+    #if there are not args, display the current config
+    if not has_updated:
+        display_config_db = LocalDbService().display_db()
+        Logger().log(display_config_db)
 
     return None

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -34,4 +34,4 @@ def config_handler(args):
         display_config_db = LocalDbService().display_db()
         Logger().log(display_config_db)
 
-    return None
+    return


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously if you try to set multiple config attributes at once, it will only set the first one and ignore the rest. In the example below only the API key was updates not the logger

```bash
> git_ai_commit config --openai-key=<api-key> --logger=False

OpenAI API key set successfully
```

## Test Plan

<!-- Provide details of a testing plan that include details on how to reproduce and success parameters. Provide screenshots/videos of log, output, etc. -->


build and install to get the latest change

```bash
> pip install . && pre-commit install && pre-commit autoupdate
```

try to set multiple configs, observe multiple attributes get configured
```
> git_ai_commit config --openai-key=<api-key> --logger=True --model=gpt-3.5-turbo

OpenAI API key set successfully
Logger disabled
Model set to gpt-3.5-turbo
```

