### PR TITLE
✨add ollama url support for config and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ git_ai_commit config --openai-key=<insert-your-key>
   git_ai_commit config --logger=<boolean>
   ```
 
+- 🌐 **--ollama-url**, **-ou**:
+  This flag allows you to set the Ollama URL for local LLM models.
+
+  ```bash
+  git_ai_commit config --ollama-url=<ollama-url>
+  ```
+
 📚 **help**, **-h**:
   This subcommand displays a list of all available commands and their usage, helping users understand how to interact with the CLI.
 

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -29,6 +29,11 @@ def config_handler(args):
         Logger().log("Model set to " + args.model)
         has_updated = True
 
+    if args.ollama_url:
+        config_service.set_ollama_url(args.ollama_url)
+        Logger().log("Ollama URL set to " + args.ollama_url)
+        has_updated = True
+
     #if there are not args, display the current config
     if not has_updated:
         display_config_db = LocalDbService().display_db()

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -29,6 +29,7 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     config_parser.add_argument('-r', '--reset', action='store_true',help='🔄 Reset the OpenAI API key to default')
     config_parser.add_argument('-l', '--logger', type=lambda x: (str(x).lower() == 'true'),help='📝 Enable or disable logging (true/false) for debugging')
     config_parser.add_argument('-m', '--model',help= '🧠 Set the OpenAI model to use for generating commit messages')
+    config_parser.add_argument('-ou', '--ollama-url', help='🌐 Set the Ollama URL for local LLM models')
 
     # Help command
     subparsers.add_parser('help', help='Display this help message')

--- a/ai_commit_msg/services/config_service.py
+++ b/ai_commit_msg/services/config_service.py
@@ -54,6 +54,12 @@ class ConfigService:
         LocalDbService().set_db({CONFIG_COLLECTION_KEY: config})
         self.model = model
 
+    def set_ollama_url(self, url):
+        config = ConfigService.get_config()
+        config["ollama_url"] = url
+        LocalDbService().set_db({CONFIG_COLLECTION_KEY: config})
+        self.ollama_url = url
+
     @staticmethod
     def is_supported_model(model):
         # check if the model has ollama prefix


### PR DESCRIPTION
## Description

In this PR I added a config flag that supports local urls for ollama!

## Test Plan

```
pip3 install . && pre-commit install && pre-commit autoupdate
```

```
> git_ai_commit config -ou=<ollama-url>

> git_ai_commit config --ollama-url=<ollama-url>

```

expected output 

```
Ollama URL set to <ollama-url>
```

double check with local db

```
git_ai_commit config 
```

