### PR TITLE
create command to setup `prepare-commit-msg` hook independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.vscode/

--- a/ai_commit_msg/cli/hook_handler.py
+++ b/ai_commit_msg/cli/hook_handler.py
@@ -1,0 +1,36 @@
+from ai_commit_msg.prepare_commit_msg_hook import prepare_commit_msg_hook
+from ai_commit_msg.services.git_service import GitService
+from ai_commit_msg.utils.logger import Logger
+
+BASH_SCRIPT="""#!/usr/bin/env bash
+
+# check if commit message is empty
+if ! grep -v "^#" "$1" | grep -q -v "^$"; then
+    # call aicommits hook --setup
+    git_ai_commit hook --run
+fi
+"""
+
+def handle_hook_setup():
+    print("Setting up prepare-commit-msg hook")
+
+    git_repo_path = GitService.get_git_directory()
+    file_path = git_repo_path + '/hooks/prepare-commit-msg'
+
+    print("file_path: " + file_path)
+
+    ## create the prepare-commit-msg file and write the hook code
+    with open(file_path, 'w') as file:
+        file.write(BASH_SCRIPT)
+
+
+def hook_handler(args):
+    if args.setup:
+        handle_hook_setup()
+    elif args.remove:
+        print("Removing prepare-commit-msg hook")
+    elif args.run:
+        Logger().log("Running prepare-commit-msg hook")
+        prepare_commit_msg_hook()
+
+    return

--- a/ai_commit_msg/cli/hook_handler.py
+++ b/ai_commit_msg/cli/hook_handler.py
@@ -11,13 +11,14 @@ if ! grep -v "^#" "$1" | grep -q -v "^$"; then
 fi
 """
 
-def handle_setup_hook():
-    print("Setting up prepare-commit-msg hook")
-
+def get_prepare_commit_msg_hook_path():
     git_repo_path = GitService.get_git_directory()
-    file_path = git_repo_path + '/hooks/prepare-commit-msg'
+    return git_repo_path + '/hooks/prepare-commit-msg'
 
-    # check if a prepare-commit-msg hook already exists
+def handle_setup_hook():
+    Logger().log("Setting up prepare-commit-msg hook")
+
+    file_path = get_prepare_commit_msg_hook_path()
 
     hook_content = ""
     if os.path.exists(file_path):
@@ -25,7 +26,7 @@ def handle_setup_hook():
           hook_content = file.read()
 
     if hook_content == PREPARE_COMMIT_MSG_BASH_SCRIPT:
-        print("prepare-commit-msg hook already exists")
+        Logger().log("prepare-commit-msg hook already exists")
         return
 
     if hook_content:
@@ -34,26 +35,25 @@ def handle_setup_hook():
       if override_content.lower() == 'n':
         return
       elif override_content.lower() != 'y':
-        print("Invalid input. Exiting.")
-
-    print("file_path: " + file_path)
+        Logger().log("Invalid input. Exiting.")
 
     ## create the prepare-commit-msg file and write the hook code
     with open(file_path, 'w') as file:
         file.write(PREPARE_COMMIT_MSG_BASH_SCRIPT)
 
+    # make the file executable
     os.chmod(file_path, 0o755)
 
 def handle_remove_hook():
-    print("Removing prepare-commit-msg hook")
-    git_repo_path = GitService.get_git_directory()
-    file_path = git_repo_path + '/hooks/prepare-commit-msg'
+    Logger().log("Removing prepare-commit-msg hook")
+
+    file_path = get_prepare_commit_msg_hook_path()
 
     try:
         os.remove(file_path)
-        print("prepare-commit-msg hook removed")
+        Logger().log("prepare-commit-msg hook removed")
     except FileNotFoundError:
-        print("prepare-commit-msg hook does not exist")
+        Logger().log("prepare-commit-msg hook does not exist")
 
     return
 

--- a/ai_commit_msg/cli/hook_handler.py
+++ b/ai_commit_msg/cli/hook_handler.py
@@ -2,11 +2,10 @@ from ai_commit_msg.prepare_commit_msg_hook import prepare_commit_msg_hook
 from ai_commit_msg.services.git_service import GitService
 from ai_commit_msg.utils.logger import Logger
 
-BASH_SCRIPT="""#!/usr/bin/env bash
+PREPARE_COMMIT_MSG_BASH_SCRIPT="""#!/usr/bin/env bash
 
 # check if commit message is empty
 if ! grep -v "^#" "$1" | grep -q -v "^$"; then
-    # call aicommits hook --setup
     git_ai_commit hook --run
 fi
 """
@@ -17,11 +16,29 @@ def handle_hook_setup():
     git_repo_path = GitService.get_git_directory()
     file_path = git_repo_path + '/hooks/prepare-commit-msg'
 
+    # check if a prepare-commit-msg hook already exists
+
+    hook_content = ""
+    with open(file_path, 'r') as file:
+        hook_content = file.read()
+
+    if hook_content == PREPARE_COMMIT_MSG_BASH_SCRIPT:
+        print("prepare-commit-msg hook already exists")
+        return
+
+    if hook_content:
+      override_content = input("prepare-commit-msg hook already exists. Would you like to overwrite it? (y/n): ")
+
+      if override_content.lower() == 'n':
+        return
+      elif override_content.lower() != 'y':
+        print("Invalid input. Exiting.")
+
     print("file_path: " + file_path)
 
     ## create the prepare-commit-msg file and write the hook code
     with open(file_path, 'w') as file:
-        file.write(BASH_SCRIPT)
+        file.write(PREPARE_COMMIT_MSG_BASH_SCRIPT)
 
 
 def hook_handler(args):

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -6,6 +6,7 @@ from typing import Sequence
 
 from ai_commit_msg.cli.config_handler import config_handler
 from ai_commit_msg.cli.gen_ai_commit_message_handler import gen_ai_commit_message_handler
+from ai_commit_msg.cli.hook_handler import hook_handler
 from ai_commit_msg.prepare_commit_msg_hook import prepare_commit_msg_hook
 from ai_commit_msg.services.local_db_service import LocalDbService
 from ai_commit_msg.utils.logger import Logger
@@ -35,12 +36,19 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     # Help command
     subparsers.add_parser('help', help='Display this help message')
 
+    # Hook command
+    hook_parser = subparsers.add_parser('hook', help='🪝 Run the prepare-commit-msg hook to generate commit messages')
+    hook_parser.add_argument('--setup', action='store_true', help='🔧 Setup the prepare-commit-msg hook')
+    hook_parser.add_argument('--remove', action='store_true', help='🔧 Setup the prepare-commit-msg hook')
+    hook_parser.add_argument('--run', action='store_true', help='🔧 Setup the prepare-commit-msg hook')
     args = parser.parse_args(argv)
 
     if args.command == 'config':
         config_handler(args)
     elif args.command == 'help':
         parser.print_help()
+    elif args.command == 'hook':
+        hook_handler(args)
 
     ## Only in main script, we return zero instead of None when the return value is unused
     return 0

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -38,9 +38,9 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
 
     # Hook command
     hook_parser = subparsers.add_parser('hook', help='🪝 Run the prepare-commit-msg hook to generate commit messages')
-    hook_parser.add_argument('--setup', action='store_true', help='🔧 Setup the prepare-commit-msg hook')
-    hook_parser.add_argument('--remove', action='store_true', help='🔧 Setup the prepare-commit-msg hook')
-    hook_parser.add_argument('--run', action='store_true', help='🔧 Setup the prepare-commit-msg hook')
+    hook_parser.add_argument('--setup', action='store_true', help='Setup the prepare-commit-msg hook')
+    hook_parser.add_argument('--remove', action='store_true', help='Remove the prepare-commit-msg hook')
+    hook_parser.add_argument('--run', action='store_true', help='Run the prepare-commit-msg hook')
     args = parser.parse_args(argv)
 
     if args.command == 'config':


### PR DESCRIPTION
## Description

Introduce a set of commands that programmatically set the `prepare-commit-msg` hook script without using the `pre-commit` framework


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Test Plan

<!-- Provide details of a testing plan that include details on how to reproduce and success parameters. Provide screenshots/videos of log, output, etc. -->

build and install for latest changes. FYI, the `pre-commit install` step will overwrite the `.git/hook/prepare-commit-msg`

```bash
pip install . && pre-commit install && pre-commit autoupdate
```

Run the following command to setup the prepare-commit-msg git hook with the pre-install framework. This should prompt you to override the existing `.git/hook/prepare-commit-msg` if it already exists
```bash
> git_ai_commit hook --setup
```

Attempt to remove `.git/hook/prepare-commit-msg`
```bash
> git_ai_commit hook --remove
```

Do setup again
```bash
> git_ai_commit hook --setup
```

Attempt to commit a change from git cli, observe AI generated commit message if there is on user provided commit message

```bash
# expect an AI-generated commit message
git commit 

# the given message should be used for the commit
git commit -m "user provided commit message"
```

Follow up

- [ ] update documentation