### PR TITLE
✨Set up NUX to set model and api keys

### DIFF
--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -3,6 +3,32 @@ from ai_commit_msg.services.local_db_service import LocalDbService
 from ai_commit_msg.services.openai_service import OpenAiService
 from ai_commit_msg.utils.logger import Logger
 
+def handle_config_setup():
+    Logger().log("\nWelcome to `git-ai-commit` - never write a commit message again!\n")
+
+    selected_model = input("""
+Select the AI model you would like to use, we support the following providers:
+    1. OpenAI GPT-4o-mini (default)
+    2. Anthropics
+    3. Ollama
+
+Select another model (press enter to skip): """
+    )
+
+    open_ai_key = input("Enter your OpenAI API key (press enter to skip): ")
+    anthropic_key = input("Enter your Anthropics API key (press enter to skip): ")
+
+    if selected_model is not "":
+        ConfigService().set_model(selected_model)
+    if open_ai_key is not "":
+        OpenAiService.set_openai_api_key(open_ai_key)
+    if anthropic_key is not "":
+        ConfigService().set_anthropic_api_key(anthropic_key)
+
+    Logger().log("Configuration setup complete")
+    return
+
+
 def config_handler(args):
     config_service = ConfigService()
 
@@ -38,6 +64,12 @@ def config_handler(args):
         config_service.set_ollama_url(args.ollama_url)
         Logger().log("Ollama URL set to " + args.ollama_url)
         has_updated = True
+
+    if args.setup:
+        handle_config_setup(config_service)
+
+        has_updated = True
+
 
     if not has_updated:
         display_config_db = LocalDbService().display_db()

--- a/ai_commit_msg/cli/config_handler.py
+++ b/ai_commit_msg/cli/config_handler.py
@@ -25,6 +25,7 @@ Select another model (press enter to skip): """
     if anthropic_key is not "":
         ConfigService().set_anthropic_api_key(anthropic_key)
 
+    ConfigService().set_last_updated_at()
     Logger().log("Configuration setup complete")
     return
 
@@ -66,8 +67,7 @@ def config_handler(args):
         has_updated = True
 
     if args.setup:
-        handle_config_setup(config_service)
-
+        handle_config_setup()
         has_updated = True
 
 

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -4,11 +4,11 @@ import sys
 import os
 from typing import Sequence
 
-from ai_commit_msg.cli.config_handler import config_handler
+from ai_commit_msg.cli.config_handler import config_handler, handle_config_setup
 from ai_commit_msg.cli.gen_ai_commit_message_handler import gen_ai_commit_message_handler
 from ai_commit_msg.cli.hook_handler import hook_handler
 from ai_commit_msg.prepare_commit_msg_hook import prepare_commit_msg_hook
-from ai_commit_msg.services.local_db_service import LocalDbService
+from ai_commit_msg.services.config_service import ConfigService
 from ai_commit_msg.utils.logger import Logger
 
 def called_from_git_hook():
@@ -19,6 +19,10 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
         return prepare_commit_msg_hook()
 
     if len(argv) == 0:
+        if(ConfigService().last_updated_at == ""):
+            handle_config_setup()
+            return 0
+
         return gen_ai_commit_message_handler()
 
     parser = argparse.ArgumentParser(description="🚀 AI-powered CLI tool that revolutionizes your Git workflow by automatically generating commit messages!")
@@ -32,6 +36,7 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     config_parser.add_argument('-m', '--model',help= '🧠 Set the OpenAI model to use for generating commit messages')
     config_parser.add_argument('-ou', '--ollama-url', help='🌐 Set the Ollama URL for local LLM models')
     config_parser.add_argument('-a', '--anthropic-key', dest='anthropic_key', help='🔑 Set your Anthropic API key for AI-powered commit messages')
+    config_parser.add_argument('-as', '--setup', action='store_true', help='🔧 Setup the tool')
 
     # Help command
     subparsers.add_parser('help', help='Display this help message')

--- a/ai_commit_msg/services/config_service.py
+++ b/ai_commit_msg/services/config_service.py
@@ -7,6 +7,8 @@ class ConfigService:
     logger_enabled = False
     model = "gpt-4o-mini"
     ollama_url = "http://localhost:11434/api/chat"
+    last_updated_at = ""
+
 
     def __init__(self):
         config = ConfigService.get_config()
@@ -16,7 +18,7 @@ class ConfigService:
         if "logger_enabled" in config: self.logger_enabled = config["logger_enabled"]
         if "model" in config: self.model = config["model"]
         if "ollama_url" in config: self.ollama_url = config["ollama_url"]
-
+        if "last_updated_at" in config: self.last_updated_at = config["last_updated_at"]
 
     @staticmethod
     def get_config():
@@ -52,7 +54,7 @@ class ConfigService:
         self.anthropic_api_key = api_key
 
     def set_model(self, model):
-        if not ConfigService.is_supported_model(model):
+        if not ConfigService.is_supported_model(model) and model is not "":
             raise Exception(f"Model {model} is not supported")
 
         config = ConfigService.get_config()

--- a/ai_commit_msg/services/config_service.py
+++ b/ai_commit_msg/services/config_service.py
@@ -1,3 +1,5 @@
+import time
+
 from ai_commit_msg.services.local_db_service import LocalDbService, CONFIG_COLLECTION_KEY
 from ai_commit_msg.utils.models import OPEN_AI_MODEL_LIST, ANTHROPIC_MODEL_LIST
 
@@ -8,7 +10,6 @@ class ConfigService:
     model = "gpt-4o-mini"
     ollama_url = "http://localhost:11434/api/chat"
     last_updated_at = ""
-
 
     def __init__(self):
         config = ConfigService.get_config()
@@ -67,6 +68,12 @@ class ConfigService:
         config["ollama_url"] = url
         LocalDbService().set_db({CONFIG_COLLECTION_KEY: config})
         self.ollama_url = url
+
+    def set_last_updated_at(self, last_updated_at = str(time.time())):
+        config = ConfigService.get_config()
+        config["last_updated_at"] = last_updated_at
+        LocalDbService().set_db({CONFIG_COLLECTION_KEY: config})
+        self.last_updated_at = last_updated_at
 
     @staticmethod
     def is_supported_model(model):

--- a/ai_commit_msg/services/local_db_service.py
+++ b/ai_commit_msg/services/local_db_service.py
@@ -1,3 +1,4 @@
+import time
 import os
 import json
 
@@ -11,7 +12,8 @@ default_db = {
       "openai_api_key": "",
       "logger_enabled": False,
       "model": "gpt-4o-mini",
-      "ollama_url": "http://localhost:11434/api/chat"
+      "ollama_url": "http://localhost:11434/api/chat",
+      "last_updated_at": ""
     }
 }
 
@@ -37,6 +39,7 @@ class LocalDbService:
             return json.load(db)
 
     def set_db(self, data):
+        data["config"]["last_updated_at"] = int(time.time())
         with open(self.db_path, 'w') as db:
             json.dump(data, db)
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR sets up the following CLI command `git_ai_commit config --setup` that triggers the NUX.

## Test Plan

<!-- Provide details of a testing plan that include details on how to reproduce and success parameters. Provide screenshots/videos of log, output, etc. -->

build and install changes locally 

```bash
pip install . && pre-commit install && pre-commit autoupdate
```

For a first time user, running the main script should trigger the NUX. To test this you can manually remove the `last_updated_at` attribute in the `/.git/.ai_commit_msg_config.json`

```
> git_ai_commit
```


Welcome to `git-ai-commit` - never write a commit message again!


Select the AI model you would like to use, we support the following providers:
    1. OpenAI GPT-4o-mini (default)
    2. Anthropics
    3. Ollama

Select another model (press enter to skip): 
Enter your OpenAI API key (press enter to skip): 
Enter your Anthropics API key (press enter to skip): 
Configuration setup complete

```
> git_ai_commit

# this time it should to generate a commit message
```

Directly access the NUX through the following command
```bash
git_ai_commit config --setup
```


